### PR TITLE
重构代码以遵循依赖倒置原则

### DIFF
--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -53,7 +53,7 @@ export interface GlobalEventMap {
     PREVIEW: [boolean]
     STOP_PREVIEW: [boolean]
     TOGGLE_PREVIEW: []
-    MOVE_TO_JUDGE_LINE: []
+    MOVE_TO_JUDGE_LINE: [number?]
     MOVE_TO_PREVIOUS_JUDGE_LINE: []
     MOVE_TO_NEXT_JUDGE_LINE: []
     REPEAT: []

--- a/src/managers/autoplay.ts
+++ b/src/managers/autoplay.ts
@@ -38,7 +38,7 @@ export default class AutoplayManager extends Manager {
                     if (hitted === "SUCCESS") {
                         // 为防止出现奇怪的打击音效，检查音频是否在播放中，只有播放中的时候才播放打击音效
                         if (audioIsPlaying) {
-                            resourcePackage.playSound(note.type, settingsManager._settings.hitSoundVolume);
+                            resourcePackage.playSound(store.audioContext, note.type, settingsManager._settings.hitSoundVolume);
                         }
                     }
                 }

--- a/src/managers/boxes.ts
+++ b/src/managers/boxes.ts
@@ -2,16 +2,16 @@ import Constants from "@/constants";
 import { NoteType } from "@/models/note";
 import store from "@/store";
 import { BoxWithData } from "@/tools/box";
-import { NoteOrEvent } from "@/models/event";
 import Manager from "./abstract";
 import { BaseEventLayer, baseEventTypes, extendedEventTypes } from "@/models/eventLayer";
+import { SelectableElement } from "@/models/element";
 
 export default class BoxesManager extends Manager {
     /**
      * 获取碰撞箱。使用绝对坐标。
      * 绝对坐标的上下和相对坐标是相反的，也就是说，虽然返回的碰撞箱top会比bottom小，但转换成相对坐标后top就会比bottom大了
      */
-    calculateBoxes(): BoxWithData<NoteOrEvent>[] {
+    calculateBoxes(): BoxWithData<SelectableElement>[] {
         const settingsManager = store.useManager("settingsManager");
         const stateManager = store.useManager("stateManager");
         const coordinateManager = store.useManager("coordinateManager");

--- a/src/managers/chartPackageLoader.ts
+++ b/src/managers/chartPackageLoader.ts
@@ -1,0 +1,55 @@
+import { ChartReadResult, ChartPackage, SYMBOL_CHART_JSON_ERROR, SYMBOL_EXTRA_JSON_ERROR } from "@/models/chartPackage";
+import { ArrayedObject } from "@/tools/algorithm";
+import MediaUtils from "@/tools/mediaUtils";
+import Manager from "./abstract";
+
+export default class ChartPackageLoader extends Manager {
+    async load(chartReadResult: ChartReadResult) {
+        return new ChartPackage({
+            musicSrc: await this.loadMusicSrc(chartReadResult.musicData),
+            background: await this.loadBackground(chartReadResult.backgroundData),
+            textures: await this.loadTextures(chartReadResult.textures),
+            chart: this.loadChart(chartReadResult.chartContent),
+            extra: this.loadExtra(chartReadResult.extraContent),
+        });
+    }
+    private async loadMusicSrc(musicData: ArrayBuffer) {
+        const musicBlob = MediaUtils.arrayBufferToBlob(musicData);
+        const musicSrc = await MediaUtils.createObjectURL(musicBlob);
+        return musicSrc;
+    }
+    private async loadBackground(backgroundData: ArrayBuffer) {
+        const backgroundBlob = MediaUtils.arrayBufferToBlob(backgroundData);
+        const backgroundSrc = await MediaUtils.createObjectURL(backgroundBlob);
+        const image = new Image();
+        image.src = backgroundSrc;
+        return image;
+    }
+    private async loadTextures(textures: Record<string, ArrayBuffer>) {
+        const arrayedObject = new ArrayedObject(textures);
+        return (await arrayedObject.map(async (key, arrayBuffer) => {
+            const src = await MediaUtils.createObjectURL(arrayBuffer);
+            const image = new Image();
+            image.src = src;
+            return image;
+        })
+            .waitPromises())
+            .toObject();
+    }
+    private loadChart(chartContent: string) {
+        try {
+            return JSON.parse(chartContent);
+        }
+        catch {
+            return SYMBOL_CHART_JSON_ERROR;
+        }
+    }
+    private loadExtra(extraContent: string) {
+        try {
+            return JSON.parse(extraContent);
+        }
+        catch {
+            return SYMBOL_EXTRA_JSON_ERROR;
+        }
+    }
+}

--- a/src/managers/clone.ts
+++ b/src/managers/clone.ts
@@ -1,12 +1,12 @@
 import { addBeats, Beats, beatsToSeconds, isGreaterThanBeats, isLessThanBeats, MAX_BEATS, MIN_BEATS, subBeats } from "@/models/beats";
 import store from "@/store";
-import { Note } from "@/models/note";
+import { isNoteLike } from "@/models/note";
 import globalEventEmitter from "@/eventEmitter";
 import Manager from "./abstract";
-import { NoteOrEvent } from "@/models/event";
 import { createCatchErrorByMessage } from "@/tools/catchError";
 import MathUtils from "@/tools/mathUtils";
 import Constants from "@/constants";
+import { SelectableElement } from "@/models/element";
 export default class CloneManager extends Manager {
     constructor() {
         super();
@@ -31,7 +31,7 @@ export default class CloneManager extends Manager {
         historyManager.group("克隆");
         while (isLessThanBeats(beats, stateManager.cache.clone.timeDuration)) {
             for (const element of selectionManager.selectedElements) {
-                if (element instanceof Note) {
+                if (isNoteLike(element)) {
                     const noteObject = element.toObject();
                     noteObject.startTime = addBeats(noteObject.startTime, beats);
                     noteObject.endTime = addBeats(noteObject.endTime, beats);
@@ -79,9 +79,9 @@ export default class CloneManager extends Manager {
 
         const length = subBeats(maxTime, minTime);
         historyManager.group("连续粘贴");
-        const elements: NoteOrEvent[] = [];
+        const elements: SelectableElement[] = [];
         for (const element of selectionManager.selectedElements) {
-            if (element instanceof Note) {
+            if (isNoteLike(element)) {
                 const noteObject = element.toObject();
                 noteObject.startTime = addBeats(noteObject.startTime, length);
                 noteObject.endTime = addBeats(noteObject.endTime, length);

--- a/src/managers/error.ts
+++ b/src/managers/error.ts
@@ -2,11 +2,12 @@ import globalEventEmitter from "@/eventEmitter";
 import Manager from "./abstract";
 import ChartError from "@/models/error";
 import store from "@/store";
-import { Note, NoteType } from "@/models/note";
+import { isNoteLike, Note, NoteType } from "@/models/note";
 import { addBeats, isEqualBeats, isGreaterThanBeats, isGreaterThanOrEqualBeats, isLessThanBeats, isLessThanOrEqualBeats } from "@/models/beats";
 import { BaseEventLayer, baseEventTypes, extendedEventTypes } from "@/models/eventLayer";
 import Constants from "@/constants";
 import { SEC_TO_MS } from "@/tools/mathUtils";
+import { isEventLike } from "@/models/event";
 
 export default class ErrorManager extends Manager {
     errors: ChartError[] = [];
@@ -79,7 +80,7 @@ export default class ErrorManager extends Manager {
                 // 检查非Hold音符有没有结束时间不等于起始时间的
                 if (note.type !== NoteType.Hold && !isEqualBeats(note.endTime, note.startTime)) {
                     this.errors.push(new ChartError(
-                        `${note.typeString} 音符时间有误，结束时间应等于起始时间`,
+                        `${NoteType[note.type]} 音符时间有误，结束时间应等于起始时间`,
                         "ChartEditError.InvalidNonHoldTime",
                         "error",
                         note
@@ -329,7 +330,7 @@ export default class ErrorManager extends Manager {
                     break;
 
                 case "ChartEditError.EventOutOfRange":
-                    if (error.objects[0] instanceof Note) {
+                    if (isNoteLike(error.objects[0])) {
                         break;
                     }
 
@@ -339,7 +340,7 @@ export default class ErrorManager extends Manager {
                     break;
 
                 case "ChartEditError.InvalidEventTime":
-                    if (error.objects[0] instanceof Note) {
+                    if (isNoteLike(error.objects[0])) {
                         break;
                     }
 
@@ -349,7 +350,7 @@ export default class ErrorManager extends Manager {
                     break;
 
                 case "ChartEditError.InvalidHoldTime":
-                    if (!(error.objects[0] instanceof Note)) {
+                    if (isEventLike(error.objects[0])) {
                         break;
                     }
 

--- a/src/managers/eventAbillities.ts
+++ b/src/managers/eventAbillities.ts
@@ -1,8 +1,8 @@
 import globalEventEmitter from "@/eventEmitter";
 import Manager from "./abstract";
 import store from "@/store";
-import { Note } from "@/models/note";
 import { createCatchErrorByMessage } from "@/tools/catchError";
+import { isEventLike } from "@/models/event";
 
 export default class EventAbillitiesManager extends Manager {
     constructor() {
@@ -17,7 +17,7 @@ export default class EventAbillitiesManager extends Manager {
     disable() {
         const selectionManager = store.useManager("selectionManager");
         for (const selectedElement of selectionManager.selectedElements) {
-            if (!(selectedElement instanceof Note)) {
+            if (isEventLike(selectedElement)) {
                 selectedElement.isDisabled = true;
             }
         }
@@ -25,7 +25,7 @@ export default class EventAbillitiesManager extends Manager {
     enable() {
         const selectionManager = store.useManager("selectionManager");
         for (const selectedElement of selectionManager.selectedElements) {
-            if (!(selectedElement instanceof Note)) {
+            if (isEventLike(selectedElement)) {
                 selectedElement.isDisabled = false;
             }
         }

--- a/src/managers/resourcePackageLoader.ts
+++ b/src/managers/resourcePackageLoader.ts
@@ -1,0 +1,250 @@
+import { ResourcePackage } from "@/models/resourcePackage";
+import { FileReaderExtends } from "@/tools/classExtends";
+import { RGBAcolor, parseRGBAfromNumber } from "@/tools/color";
+import EditableImage from "@/tools/editableImage";
+import MediaUtils from "@/tools/mediaUtils";
+import { isArrayOfNumbers } from "@/tools/typeTools";
+import jsyaml from "js-yaml";
+import JSZip from "jszip";
+import { isObject, isNumber, isBoolean, mean } from "lodash";
+import Manager from "./abstract";
+import store from "@/store";
+
+/* eslint-disable no-magic-numbers */
+const
+    DEFAULT_HITFX = [5, 6] as [number, number],
+    DEFAULT_HOLD_ATLAS = [50, 50] as [number, number],
+    DEFAULT_HOLD_ATLAS_MH = [50, 110] as [number, number],
+    DEFAULT_HITFX_DURATION = 0.5,
+    DEFAULT_HITFX_SCALE = 1.0,
+    DEFAULT_HITFX_ROTATE = false,
+    DEFAULT_HITFX_TINTED = true,
+    DEFAULT_HIDE_PARTICLES = false,
+    DEFAULT_HOLD_KEEPHEAD = false,
+    DEFAULT_HOLD_REPEAT = false,
+    DEFAULT_HOLD_COMPACT = false,
+    DEFAULT_COLOR_PERFECT: RGBAcolor = [0xff, 0xec, 0x9f, 0xe1],
+    DEFAULT_COLOR_GOOD: RGBAcolor = [0xb4, 0xe1, 0xff, 0xeb],
+    HITFX_SIZE = 256;
+/* eslint-enable no-magic-numbers */
+
+export default class ResourcePackageLoader extends Manager {
+    load(arrayBuffer: ArrayBuffer, progressHandler?: (e: ResPakLoadProgress) => void) {
+        return new Promise<ResourcePackage>((resolve) => {
+            const blob = MediaUtils.arrayBufferToBlob(arrayBuffer);
+            const reader = new FileReaderExtends();
+            resolve(
+                reader.readAsync(blob, "arraybuffer", function (e: ProgressEvent) {
+                    if (progressHandler) {
+                        progressHandler({
+                            progress: e.loaded / e.total * 100,
+                            description: "读取资源包内容"
+                        });
+                    }
+                }).then(async result => {
+                    const zip = await JSZip.loadAsync(result);
+
+                    /*
+                    资源文件必须包括：
+                    click.png 和 click_mh.png：Click 音符的皮肤，mh 代表双押；为什么要用click而不是tap啊，tap不是本来的名字吗
+                    drag.png 和 drag_mh.png：Drag 音符的皮肤，mh 代表双押；为什么要用mh代表双押啊，要用HL就别用mh行不行
+                    flick.png 和 flick_mh.png：Flick 音符的皮肤，mh 代表双押；算了吧，还是把各种可能的名字都匹配上吧
+                    hold.png 和 hold_mh.png：Hold 音符的皮肤，mh 代表双押；
+                    hit_fx.png：打击特效图片。
+                    资源文件可以包括（即若不包括，将使用默认）：
+                    click.ogg、drag.ogg 和 flick.ogg：对应音符的打击音效，注意采样率必须为 44100Hz，否则在渲染时（prpr - render）会导致崩溃；
+                    ending.mp3：结算界面背景音乐。
+                    */
+                    const tapPictireFile = zip.file(/(click|tap|blue)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
+                    const tapHLPictireFile = zip.file(/(click|tap|blue)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || tapPictireFile;
+                    const dragPictireFile = zip.file(/(drag|yellow)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
+                    const dragHLPictireFile = zip.file(/(drag|yellow)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || dragPictireFile;
+                    const flickPictireFile = zip.file(/(flick|slide|red|pink)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
+                    const flickHLPictireFile = zip.file(/(flick|slide|red|pink)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || flickPictireFile;
+                    const holdPictireFile = zip.file(/(hold|long)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
+                    const holdHLPictireFile = zip.file(/(hold|long)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || holdPictireFile;
+                    if (!tapPictireFile) throw new Error("Missing tap picture (tap.png, blue.png or click.png)");
+                    if (!dragPictireFile) throw new Error("Missing drag picture (drag.png or yellow.png)");
+                    if (!flickPictireFile) throw new Error("Missing flick picture (flick.png, slide.png, red.png or pink.png)");
+                    if (!holdPictireFile) throw new Error("Missing hold picture (hold.png or long.png)");
+                    const tapSoundFile = zip.file(/(click|tap|blue)\.(ogg|mp3|wav|m4a)/i)[0];
+                    const dragSoundFile = zip.file(/(drag|yellow)\.(ogg|mp3|wav|m4a)/i)[0];
+                    const flickSoundFile = zip.file(/(flick|slide|red|pink)\.(ogg|mp3|wav|m4a)/i)[0];
+                    const hitFxPictureFile = zip.file(/hit[_\- ]?fx.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
+                    if (!tapSoundFile) throw new Error("Missing tap sound (tap.ogg, blue.ogg or click.ogg)");
+                    if (!dragSoundFile) throw new Error("Missing drag sound (drag.ogg or yellow.ogg)");
+                    if (!flickSoundFile) throw new Error("Missing flick sound (flick.ogg, slide.ogg, red.ogg or pink.ogg)");
+                    if (!hitFxPictureFile) throw new Error("Missing hit picture (hit_fx.png)");
+                    const info = zip.file(/info\.(yml|json)$/)[0];
+                    if (!info) throw new Error("Missing info file (info.yml or info.json)");
+                    const infoContent = await info.async("text");
+                    const infoObj: unknown = info.name.endsWith(".json") ? JSON.parse(infoContent) : jsyaml.load(infoContent);
+                    if (!isObject(infoObj)) throw new Error("Invalid info file");
+                    let hitFx: [number, number] = DEFAULT_HITFX,
+                        holdAtlas: [number, number] = DEFAULT_HOLD_ATLAS,
+                        holdAtlasMH: [number, number] = DEFAULT_HOLD_ATLAS_MH,
+                        hitFxDuration = DEFAULT_HITFX_DURATION,
+                        hitFxScale = DEFAULT_HITFX_SCALE,
+                        hitFxRotate = DEFAULT_HITFX_ROTATE,
+                        hitFxTinted = DEFAULT_HITFX_TINTED,
+                        hideParticles = DEFAULT_HIDE_PARTICLES,
+                        holdKeepHead = DEFAULT_HOLD_KEEPHEAD,
+                        holdRepeat = DEFAULT_HOLD_REPEAT,
+                        holdCompact = DEFAULT_HOLD_COMPACT,
+                        colorPerfect: RGBAcolor = DEFAULT_COLOR_PERFECT,
+                        colorGood: RGBAcolor = DEFAULT_COLOR_GOOD;
+                    if ("hitFx" in infoObj && isArrayOfNumbers(infoObj.hitFx, 2)) hitFx = infoObj.hitFx;
+                    else throw new Error("Missing property hitFx in info file");
+                    if ("holdAtlas" in infoObj && isArrayOfNumbers(infoObj.holdAtlas, 2)) holdAtlas = infoObj.holdAtlas;
+                    else throw new Error("Missing property holdAtlas in info file");
+                    if ("holdAtlasMH" in infoObj && isArrayOfNumbers(infoObj.holdAtlasMH, 2)) holdAtlasMH = infoObj.holdAtlasMH;
+                    else throw new Error("Missing property holdAtlasMH in info file");
+                    if ("hitFxDuration" in infoObj && isNumber(infoObj.hitFxDuration)) hitFxDuration = infoObj.hitFxDuration;
+                    if ("hitFxScale" in infoObj && isNumber(infoObj.hitFxScale)) hitFxScale = infoObj.hitFxScale;
+                    if ("hitFxRotate" in infoObj && isBoolean(infoObj.hitFxRotate)) hitFxRotate = infoObj.hitFxRotate;
+                    if ("hitFxTinted" in infoObj && isBoolean(infoObj.hitFxTinted)) hitFxTinted = infoObj.hitFxTinted;
+                    if ("hideParticles" in infoObj && isBoolean(infoObj.hideParticles)) hideParticles = infoObj.hideParticles;
+                    if ("holdKeepHead" in infoObj && isBoolean(infoObj.holdKeepHead)) holdKeepHead = infoObj.holdKeepHead;
+                    if ("holdRepeat" in infoObj && isBoolean(infoObj.holdRepeat)) holdRepeat = infoObj.holdRepeat;
+                    if ("holdCompact" in infoObj && isBoolean(infoObj.holdCompact)) holdCompact = infoObj.holdCompact;
+                    if ("colorPerfect" in infoObj && isNumber(infoObj.colorPerfect)) colorPerfect = parseRGBAfromNumber(infoObj.colorPerfect);
+                    if ("colorGood" in infoObj && isNumber(infoObj.colorGood)) colorGood = parseRGBAfromNumber(infoObj.colorGood);
+                    const progress = {
+                        tapSound: 0,
+                        dragSound: 0,
+                        flickSound: 0,
+                        tap: 0,
+                        drag: 0,
+                        flick: 0,
+                        hold: 0,
+                        tapHL: 0,
+                        dragHL: 0,
+                        flickHL: 0,
+                        holdHL: 0,
+                        hitFx: 0
+                    };
+                    const _showProgress = () => {
+                        if (progressHandler) {
+                            progressHandler({
+                                description: "读取资源包中的文件",
+                                progress: mean(Object.values(progress))
+                            });
+                        }
+                    };
+
+                    const tapSoundPromise = tapSoundFile.async("arraybuffer", meta => {
+                        progress.tapSound = meta.percent;
+                        _showProgress();
+                    }).then(MediaUtils.createAudioBuffer.bind(store.audioContext));
+                    const dragSoundPromise = dragSoundFile.async("arraybuffer", meta => {
+                        progress.dragSound = meta.percent;
+                        _showProgress();
+                    }).then(MediaUtils.createAudioBuffer.bind(store.audioContext));
+                    const flickSoundPromise = flickSoundFile.async("arraybuffer", meta => {
+                        progress.flickSound = meta.percent;
+                        _showProgress();
+                    }).then(MediaUtils.createAudioBuffer.bind(store.audioContext));
+                    const hitFxImagePromise = hitFxPictureFile.async("blob", meta => {
+                        progress.hitFx = meta.percent;
+                        _showProgress();
+                    }).then(MediaUtils.createImage);
+                    const
+                        tapPromise = tapPictireFile.async("blob", meta => {
+                            progress.tap = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        dragPromise = dragPictireFile.async("blob", meta => {
+                            progress.drag = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        flickPromise = flickPictireFile.async("blob", meta => {
+                            progress.flick = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        holdPromise = holdPictireFile.async("blob", meta => {
+                            progress.hold = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        tapHLPromise = tapHLPictireFile.async("blob", meta => {
+                            progress.tapHL = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        dragHLPromise = dragHLPictireFile.async("blob", meta => {
+                            progress.dragHL = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        flickHLPromise = flickHLPictireFile.async("blob", meta => {
+                            progress.flickHL = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage),
+                        holdHLPromise = holdHLPictireFile.async("blob", meta => {
+                            progress.holdHL = meta.percent;
+                            _showProgress();
+                        }).then(MediaUtils.createImage);
+                    const [tapSound, dragSound, flickSound, hitFxImage,
+                        tap, drag, flick, hold,
+                        tapHL, dragHL, flickHL, holdHL] =
+                        await Promise.all([
+                            tapSoundPromise, dragSoundPromise, flickSoundPromise, hitFxImagePromise,
+                            tapPromise, dragPromise, flickPromise, holdPromise,
+                            tapHLPromise, dragHLPromise, flickHLPromise, holdHLPromise
+                        ]);
+                    const holdHead = new EditableImage(hold)
+                        .cutTop(hold.height - holdAtlas[1])
+                        .canvas;
+                    const holdEnd = new EditableImage(hold)
+                        .cutBottom(hold.height - holdAtlas[0])
+                        .canvas;
+                    const holdBody = new EditableImage(hold)
+                        .cutTop(holdAtlas[0])
+                        .cutBottom(holdAtlas[1])
+                        .canvas;
+                    const holdHLHead = new EditableImage(holdHL)
+                        .cutTop(holdHL.height - holdAtlasMH[1])
+                        .canvas;
+                    const holdHLEnd = new EditableImage(holdHL)
+                        .cutBottom(holdHL.height - holdAtlasMH[0])
+                        .canvas;
+                    const holdHLBody = new EditableImage(holdHL)
+                        .cutTop(holdAtlasMH[0])
+                        .cutBottom(holdAtlasMH[1])
+                        .canvas;
+                    const hitFxWidth = hitFxImage.width / hitFx[0];
+                    const hitFxHeight = hitFxImage.height / hitFx[1];
+                    const perfectHitFxFrames: HTMLCanvasElement[] = [];
+                    const goodHitFxFrames: HTMLCanvasElement[] = [];
+                    for (let i = 0; i < hitFx[1]; i++) {
+                        for (let j = 0; j < hitFx[0]; j++) {
+                            const perfectHitFxFrame = new EditableImage(hitFxImage, j * hitFxWidth, i * hitFxHeight, hitFxWidth, hitFxHeight);
+                            perfectHitFxFrame.stretch(HITFX_SIZE * hitFxScale, HITFX_SIZE * hitFxScale);
+                            const goodHitFxFrame = perfectHitFxFrame.clone();
+                            const coloredFramePerfect = hitFxTinted ? perfectHitFxFrame.color(colorPerfect) : perfectHitFxFrame;
+                            const coloredFrameGood = hitFxTinted ? goodHitFxFrame.color(colorGood) : goodHitFxFrame;
+                            perfectHitFxFrames.push(coloredFramePerfect.canvas);
+                            goodHitFxFrames.push(coloredFrameGood.canvas);
+                        }
+                    }
+                    return new ResourcePackage({
+                        tap, drag, flick, holdHead, holdEnd, holdBody, hold,
+                        tapHL, dragHL, flickHL, holdHLHead, holdHLEnd, holdHLBody, holdHL,
+                        tapSound, dragSound, flickSound,
+                        perfectHitFxFrames, goodHitFxFrames,
+                        config: {
+                            hitFxDuration, hitFxRotate, hideParticles,
+                            holdKeepHead, holdRepeat, holdCompact,
+                            colorPerfect, colorGood
+                        }
+                    });
+                })
+            );
+        });
+    }
+}
+interface ResPakLoadProgress {
+
+    /** 加载描述 */
+    description: string;
+
+    /** 加载进度 */
+    progress: number;
+}

--- a/src/managers/selection.ts
+++ b/src/managers/selection.ts
@@ -1,15 +1,15 @@
-import { NoteOrEvent } from "@/models/event";
 import { reactive } from "vue";
 import globalEventEmitter from "@/eventEmitter";
-import { Note } from "@/models/note";
+import { isNoteLike } from "@/models/note";
 import store from "@/store";
 import Manager from "./abstract";
 import { BaseEventLayer, baseEventTypes, extendedEventTypes } from "@/models/eventLayer";
 import { createCatchErrorByMessage } from "@/tools/catchError";
+import { SelectableElement } from "@/models/element";
 
 export default class SelectionManager extends Manager {
     /** 被选中的元素。有时也用“selection”来代替“selectedElements”。 */
-    readonly selectedElements: NoteOrEvent[] = reactive([]);
+    readonly selectedElements: SelectableElement[] = reactive([]);
     constructor() {
         super();
         globalEventEmitter.on("DELETE", createCatchErrorByMessage(() => {
@@ -31,14 +31,14 @@ export default class SelectionManager extends Manager {
     }
 
     /** 取消选择所有元素，并选择指定的元素 */
-    select(elements: NoteOrEvent[]) {
+    select(elements: SelectableElement[]) {
         this.selectedElements.splice(0);
         this.selectedElements.push(...elements);
         globalEventEmitter.emit("SELECTION_UPDATE");
     }
 
     /** 在原有选择的基础上添加元素 */
-    addToSelection(elements: NoteOrEvent[]) {
+    addToSelection(elements: SelectableElement[]) {
         let selectionIsChanged = false;
         for (const element of elements) {
             if (!this.selectedElements.includes(element)) {
@@ -53,7 +53,7 @@ export default class SelectionManager extends Manager {
     }
 
     /** 在原有选择的基础上移除元素 */
-    removeFromSelection(elements: NoteOrEvent[]) {
+    removeFromSelection(elements: SelectableElement[]) {
         let selectionIsChanged = false;
         for (const element of elements) {
             const index = this.selectedElements.indexOf(element);
@@ -70,7 +70,7 @@ export default class SelectionManager extends Manager {
             globalEventEmitter.emit("SELECTION_UPDATE");
         }
     }
-    isSelected(element: NoteOrEvent) {
+    isSelected(element: SelectableElement) {
         return this.selectedElements.includes(element);
     }
 
@@ -91,7 +91,7 @@ export default class SelectionManager extends Manager {
         mouseManager.checkMouseUp();
         historyManager.group("删除");
         for (const element of this.selectedElements) {
-            if (element instanceof Note) {
+            if (isNoteLike(element)) {
                 store.removeNote(element.id);
                 historyManager.recordRemoveNote(element.toObject(), element.judgeLineNumber, element.id);
             }

--- a/src/models/chartMeta.ts
+++ b/src/models/chartMeta.ts
@@ -37,6 +37,8 @@ export interface IChartMeta {
 
 /** 当前是 0.1.0 版本 */
 const VERSION = 10;
+
+/** 谱面元数据，是响应式的 */
 export class ChartMeta implements IChartMeta, IObjectizable {
     charter = "unknown";
     composer = "unknown";

--- a/src/models/chartPackage.ts
+++ b/src/models/chartPackage.ts
@@ -1,8 +1,6 @@
-import MediaUtils from "@/tools/mediaUtils";
 import { Chart, IChart } from "./chart";
 import ChartError from "./error";
 import { Extra, IExtra } from "./extra";
-import { ArrayedObject } from "@/tools/algorithm";
 export interface IChartPackage {
     chart: IChart;
     background: HTMLImageElement;
@@ -37,57 +35,10 @@ export class ChartPackage implements IChartPackage {
         this.errors.push(...this.chart.errors);
         this.errors.push(...this.extra.errors);
 
+        // 强制使 extra.bpm 与 chart.BPMList 相同
         this.extra.bpm.length = 0;
         this.extra.bpm.push(...this.chart.BPMList);
         this.extra.calculateSeconds();
-    }
-    static async loadFromChartReadResult(chartReadResult: ChartReadResult) {
-        return new ChartPackage({
-            musicSrc: await this.loadMusicSrc(chartReadResult.musicData),
-            background: await this.loadBackground(chartReadResult.backgroundData),
-            textures: await this.loadTextures(chartReadResult.textures),
-            chart: this.loadChart(chartReadResult.chartContent),
-            extra: this.loadExtra(chartReadResult.extraContent),
-        });
-    }
-    private static async loadMusicSrc(musicData: ArrayBuffer) {
-        const musicBlob = MediaUtils.arrayBufferToBlob(musicData);
-        const musicSrc = await MediaUtils.createObjectURL(musicBlob);
-        return musicSrc;
-    }
-    private static async loadBackground(backgroundData: ArrayBuffer) {
-        const backgroundBlob = MediaUtils.arrayBufferToBlob(backgroundData);
-        const backgroundSrc = await MediaUtils.createObjectURL(backgroundBlob);
-        const image = new Image();
-        image.src = backgroundSrc;
-        return image;
-    }
-    private static async loadTextures(textures: Record<string, ArrayBuffer>) {
-        const arrayedObject = new ArrayedObject(textures);
-        return (await arrayedObject.map(async (key, arrayBuffer) => {
-            const src = await MediaUtils.createObjectURL(arrayBuffer);
-            const image = new Image();
-            image.src = src;
-            return image;
-        })
-            .waitPromises())
-            .toObject();
-    }
-    private static loadChart(chartContent: string) {
-        try {
-            return JSON.parse(chartContent);
-        }
-        catch {
-            return SYMBOL_CHART_JSON_ERROR;
-        }
-    }
-    private static loadExtra(extraContent: string) {
-        try {
-            return JSON.parse(extraContent);
-        }
-        catch {
-            return SYMBOL_EXTRA_JSON_ERROR;
-        }
     }
 }
 

--- a/src/models/element.ts
+++ b/src/models/element.ts
@@ -1,0 +1,8 @@
+import { IEvent, IEventExtendedOptions } from "./event";
+import { INote, INoteExtendedOptions } from "./note";
+import { IObjectizable } from "./objectizable";
+import { TimeSegment } from "./timeSegment";
+
+export type FullNote = INote & INoteExtendedOptions & IObjectizable<INote> & TimeSegment;
+export type FullEvent<T = unknown> = IEvent<T> & IEventExtendedOptions & IObjectizable<IEvent> & TimeSegment;
+export type SelectableElement = FullNote | FullEvent;

--- a/src/models/error.ts
+++ b/src/models/error.ts
@@ -1,5 +1,4 @@
-import { NumberEvent, ColorEvent, TextEvent } from "./event";
-import { Note } from "./note";
+import { SelectableElement } from "./element";
 type ErrorCode = "ChartReadError.TypeError" | "ChartReadError.MissingProperty" | "ChartReadError.OutOfRange" |
     "ChartReadError.FormatError" |
     "ChartEditError.InvalidHoldTime" | "ChartEditError.InvalidNonHoldTime" | "ChartEditError.NoteOutOfRange" |
@@ -8,11 +7,11 @@ type ErrorCode = "ChartReadError.TypeError" | "ChartReadError.MissingProperty" |
     "ChartEditError.TapAfterDrag" | "ChartEditError.TapAfterFlick" | "ChartEditError.NotSupported" |
     "ChartEditError.InvalidEasingLeftRight" | "ChartEditError.EventDisabled"
 export default class ChartError {
-    objects: (NumberEvent | ColorEvent | TextEvent | Note)[];
+    objects: SelectableElement[];
     constructor(public message: string,
         public code: ErrorCode,
         public level: "error" | "warning" | "info" = "error",
-        ...objects: (Note | NumberEvent | ColorEvent | TextEvent)[]) {
+        ...objects: SelectableElement[]) {
         this.objects = objects;
     }
 }

--- a/src/models/eventLayer.ts
+++ b/src/models/eventLayer.ts
@@ -37,15 +37,38 @@ export const extendedEventTypes = [
     "text",
 
     // "incline",
-    // "shader",
     // "gif",
 ] as const;
-export class BaseEventLayer extends AbstractEventLayer implements IBaseEventLayer {
+
+export interface IBaseEventLayerIdentifier {
+    readonly isBaseEventLayer: true;
+}
+
+export interface IExtendedEventLayerIdentifier {
+    readonly isExtendedEventLayer: true;
+}
+
+export function isBaseEventLayer(value: unknown): value is IBaseEventLayer {
+    if (!isObject(value)) {
+        return false;
+    }
+    return "isBaseEventLayer" in value;
+}
+
+export function isExtendedEventLayer(value: unknown): value is IExtendedEventLayer {
+    if (!isObject(value)) {
+        return false;
+    }
+    return "isExtendedEventLayer" in value;
+}
+
+export class BaseEventLayer extends AbstractEventLayer implements IBaseEventLayer, IBaseEventLayerIdentifier {
     moveXEvents: NumberEvent[] = [];
     moveYEvents: NumberEvent[] = [];
     rotateEvents: NumberEvent[] = [];
     alphaEvents: NumberEvent[] = [];
     speedEvents: NumberEvent[] = [];
+    readonly isBaseEventLayer = true;
     eventNumbers = {
         moveX: 0,
         moveY: 0,
@@ -162,7 +185,9 @@ export class BaseEventLayer extends AbstractEventLayer implements IBaseEventLaye
             if (events.length === 0) {
                 this.addEvent({
                     start: 0,
-                    end: 0
+                    end: 0,
+                    startTime: [0, 0, 1],
+                    endTime: [1, 0, 1],
                 }, type);
             }
         }
@@ -178,13 +203,14 @@ export interface IExtendedEventLayer {
 }
 
 /** 暂不支持 paint 和 incline 事件 */
-export class ExtendedEventLayer extends AbstractEventLayer implements IExtendedEventLayer {
+export class ExtendedEventLayer extends AbstractEventLayer implements IExtendedEventLayer, IExtendedEventLayerIdentifier {
     scaleXEvents: NumberEvent[] = [];
     scaleYEvents: NumberEvent[] = [];
     colorEvents: ColorEvent[] = [];
     paintEvents: NumberEvent[] = [];
     textEvents: TextEvent[] = [];
     inclineEvents: NumberEvent[] = [];
+    readonly isExtendedEventLayer = true;
     eventNumbers = {
         scaleX: 0,
         scaleY: 0,

--- a/src/models/judgeLine.ts
+++ b/src/models/judgeLine.ts
@@ -7,7 +7,7 @@ import { beatsCompare, BPM } from "./beats";
 import ChartError from "./error";
 import { isArrayOfNumbers } from "@/tools/typeTools";
 import { IObjectizable } from "./objectizable";
-interface JudgeLineOptions {
+export interface JudgeLineExtendedOptions {
     BPMList: BPM[],
     judgeLineNumber: number
 }
@@ -115,7 +115,7 @@ const DEFAULT_X_MIN = 0;
 const MAX_EVENT_LAYERS = 4;
 const SPEED_RATIO = 120;
 
-export class JudgeLine implements IJudgeLine, IObjectizable {
+export class JudgeLine implements IJudgeLine, IObjectizable<IJudgeLine> {
     Group = DEFAULT_GROUP;
     Name = DEFAULT_NAME;
     Texture = DEFAULT_TEXTURE;
@@ -446,7 +446,7 @@ export class JudgeLine implements IJudgeLine, IObjectizable {
         }
         return false;
     }
-    constructor(judgeLine: unknown, readonly options: JudgeLineOptions) {
+    constructor(judgeLine: unknown, readonly options: JudgeLineExtendedOptions) {
         this.id = options.judgeLineNumber;
         if (isObject(judgeLine)) {
             if ("Group" in judgeLine) {

--- a/src/models/objectizable.ts
+++ b/src/models/objectizable.ts
@@ -1,3 +1,3 @@
-export interface IObjectizable {
-    toObject(): object;
+export interface IObjectizable<T = object> {
+    toObject(): T;
 }

--- a/src/models/resourcePackage.ts
+++ b/src/models/resourcePackage.ts
@@ -1,13 +1,6 @@
-import JSZip from "jszip";
-import { isArrayOfNumbers } from "../tools/typeTools";
-import { FileReaderExtends } from "../tools/classExtends";
-import EditableImage from "../tools/editableImage";
-import jsyaml from "js-yaml";
-import { parseRGBAfromNumber, RGBAcolor } from "../tools/color";
+import { RGBAcolor } from "../tools/color";
 import { NoteType } from "./note";
-import { isObject, isNumber, isBoolean, mean } from "lodash";
 import MediaUtils from "../tools/mediaUtils";
-type Image = HTMLImageElement | HTMLCanvasElement;
 interface IResourcePackage {
     tap: HTMLImageElement;
     flick: HTMLImageElement;
@@ -26,8 +19,8 @@ interface IResourcePackage {
     tapSound: AudioBuffer;
     dragSound: AudioBuffer;
     flickSound: AudioBuffer;
-    perfectHitFxFrames: Image[];
-    goodHitFxFrames: Image[];
+    perfectHitFxFrames: HTMLCanvasElement[];
+    goodHitFxFrames: HTMLCanvasElement[];
     config: ResourceConfig;
 }
 interface ResourceConfig {
@@ -62,25 +55,6 @@ interface ResourceConfig {
     /** FC（全连）情况下的判定线颜色 */
     colorGood: RGBAcolor;
 }
-const audioContext = new AudioContext();
-
-/* eslint-disable no-magic-numbers */
-const
-    DEFAULT_HITFX = [5, 6] as [number, number],
-    DEFAULT_HOLD_ATLAS = [50, 50] as [number, number],
-    DEFAULT_HOLD_ATLAS_MH = [50, 110] as [number, number],
-    DEFAULT_HITFX_DURATION = 0.5,
-    DEFAULT_HITFX_SCALE = 1.0,
-    DEFAULT_HITFX_ROTATE = false,
-    DEFAULT_HITFX_TINTED = true,
-    DEFAULT_HIDE_PARTICLES = false,
-    DEFAULT_HOLD_KEEPHEAD = false,
-    DEFAULT_HOLD_REPEAT = false,
-    DEFAULT_HOLD_COMPACT = false,
-    DEFAULT_COLOR_PERFECT: RGBAcolor = [0xff, 0xec, 0x9f, 0xe1],
-    DEFAULT_COLOR_GOOD: RGBAcolor = [0xb4, 0xe1, 0xff, 0xeb],
-    HITFX_SIZE = 256;
-/* eslint-enable no-magic-numbers */
 
 export class ResourcePackage implements IResourcePackage {
     tap: HTMLImageElement;
@@ -100,8 +74,8 @@ export class ResourcePackage implements IResourcePackage {
     tapSound: AudioBuffer;
     dragSound: AudioBuffer;
     flickSound: AudioBuffer;
-    perfectHitFxFrames: Image[];
-    goodHitFxFrames: Image[];
+    perfectHitFxFrames: HTMLCanvasElement[];
+    goodHitFxFrames: HTMLCanvasElement[];
     config: ResourceConfig;
     getSkin(noteType: NoteType.Hold, highlight: boolean): { head: HTMLCanvasElement, body: HTMLCanvasElement, end: HTMLCanvasElement };
     getSkin(noteType: NoteType.Tap | NoteType.Drag | NoteType.Flick, highlight: boolean): HTMLImageElement;
@@ -147,7 +121,7 @@ export class ResourcePackage implements IResourcePackage {
             }
         }
     }
-    playSound(noteType: NoteType, volume = 1) {
+    playSound(audioContext: AudioContext, noteType: NoteType, volume = 1) {
         switch (noteType) {
             case NoteType.Tap:
             case NoteType.Hold:
@@ -183,222 +157,4 @@ export class ResourcePackage implements IResourcePackage {
         this.goodHitFxFrames = resourcePackage.goodHitFxFrames;
         this.config = resourcePackage.config;
     }
-    static load(arrayBuffer: ArrayBuffer, progressHandler?: (e: ResPakLoadProgress) => void) {
-        return new Promise<ResourcePackage>((resolve) => {
-            const blob = MediaUtils.arrayBufferToBlob(arrayBuffer);
-            const reader = new FileReaderExtends();
-            resolve(
-                reader.readAsync(blob, "arraybuffer", function (e: ProgressEvent) {
-                    if (progressHandler) {
-                        progressHandler({
-                            progress: e.loaded / e.total * 100,
-                            description: "读取资源包内容"
-                        });
-                    }
-                }).then(async result => {
-                    const zip = await JSZip.loadAsync(result);
-
-                    /*
-                    资源文件必须包括：
-                    click.png 和 click_mh.png：Click 音符的皮肤，mh 代表双押；为什么要用click而不是tap啊，tap不是本来的名字吗
-                    drag.png 和 drag_mh.png：Drag 音符的皮肤，mh 代表双押；为什么要用mh代表双押啊，要用HL就别用mh行不行
-                    flick.png 和 flick_mh.png：Flick 音符的皮肤，mh 代表双押；算了吧，还是把各种可能的名字都匹配上吧
-                    hold.png 和 hold_mh.png：Hold 音符的皮肤，mh 代表双押；
-                    hit_fx.png：打击特效图片。
-                    资源文件可以包括（即若不包括，将使用默认）：
-                    click.ogg、drag.ogg 和 flick.ogg：对应音符的打击音效，注意采样率必须为 44100Hz，否则在渲染时（prpr - render）会导致崩溃；
-                    ending.mp3：结算界面背景音乐。
-                    */
-                    const tapPictireFile = zip.file(/(click|tap|blue)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
-                    const tapHLPictireFile = zip.file(/(click|tap|blue)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || tapPictireFile;
-                    const dragPictireFile = zip.file(/(drag|yellow)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
-                    const dragHLPictireFile = zip.file(/(drag|yellow)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || dragPictireFile;
-                    const flickPictireFile = zip.file(/(flick|slide|red|pink)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
-                    const flickHLPictireFile = zip.file(/(flick|slide|red|pink)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || flickPictireFile;
-                    const holdPictireFile = zip.file(/(hold|long)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
-                    const holdHLPictireFile = zip.file(/(hold|long)[_\- ]?(mh|hl)\.(png|jpg|jpeg|bmp|gif|svg)/i)[0] || holdPictireFile;
-                    if (!tapPictireFile) throw new Error("Missing tap picture (tap.png, blue.png or click.png)");
-                    if (!dragPictireFile) throw new Error("Missing drag picture (drag.png or yellow.png)");
-                    if (!flickPictireFile) throw new Error("Missing flick picture (flick.png, slide.png, red.png or pink.png)");
-                    if (!holdPictireFile) throw new Error("Missing hold picture (hold.png or long.png)");
-                    const tapSoundFile = zip.file(/(click|tap|blue)\.(ogg|mp3|wav|m4a)/i)[0];
-                    const dragSoundFile = zip.file(/(drag|yellow)\.(ogg|mp3|wav|m4a)/i)[0];
-                    const flickSoundFile = zip.file(/(flick|slide|red|pink)\.(ogg|mp3|wav|m4a)/i)[0];
-                    const hitFxPictureFile = zip.file(/hit[_\- ]?fx.(png|jpg|jpeg|bmp|gif|svg)/i)[0];
-                    if (!tapSoundFile) throw new Error("Missing tap sound (tap.ogg, blue.ogg or click.ogg)");
-                    if (!dragSoundFile) throw new Error("Missing drag sound (drag.ogg or yellow.ogg)");
-                    if (!flickSoundFile) throw new Error("Missing flick sound (flick.ogg, slide.ogg, red.ogg or pink.ogg)");
-                    if (!hitFxPictureFile) throw new Error("Missing hit picture (hit_fx.png)");
-                    const info = zip.file(/info\.(yml|json)$/)[0];
-                    if (!info) throw new Error("Missing info file (info.yml or info.json)");
-                    const infoContent = await info.async("text");
-                    const infoObj: unknown = info.name.endsWith(".json") ? JSON.parse(infoContent) : jsyaml.load(infoContent);
-                    if (!isObject(infoObj)) throw new Error("Invalid info file");
-                    let hitFx: [number, number] = DEFAULT_HITFX,
-                        holdAtlas: [number, number] = DEFAULT_HOLD_ATLAS,
-                        holdAtlasMH: [number, number] = DEFAULT_HOLD_ATLAS_MH,
-                        hitFxDuration = DEFAULT_HITFX_DURATION,
-                        hitFxScale = DEFAULT_HITFX_SCALE,
-                        hitFxRotate = DEFAULT_HITFX_ROTATE,
-                        hitFxTinted = DEFAULT_HITFX_TINTED,
-                        hideParticles = DEFAULT_HIDE_PARTICLES,
-                        holdKeepHead = DEFAULT_HOLD_KEEPHEAD,
-                        holdRepeat = DEFAULT_HOLD_REPEAT,
-                        holdCompact = DEFAULT_HOLD_COMPACT,
-                        colorPerfect: RGBAcolor = DEFAULT_COLOR_PERFECT,
-                        colorGood: RGBAcolor = DEFAULT_COLOR_GOOD;
-                    if ("hitFx" in infoObj && isArrayOfNumbers(infoObj.hitFx, 2)) hitFx = infoObj.hitFx;
-                    else throw new Error("Missing property hitFx in info file");
-                    if ("holdAtlas" in infoObj && isArrayOfNumbers(infoObj.holdAtlas, 2)) holdAtlas = infoObj.holdAtlas;
-                    else throw new Error("Missing property holdAtlas in info file");
-                    if ("holdAtlasMH" in infoObj && isArrayOfNumbers(infoObj.holdAtlasMH, 2)) holdAtlasMH = infoObj.holdAtlasMH;
-                    else throw new Error("Missing property holdAtlasMH in info file");
-                    if ("hitFxDuration" in infoObj && isNumber(infoObj.hitFxDuration)) hitFxDuration = infoObj.hitFxDuration;
-                    if ("hitFxScale" in infoObj && isNumber(infoObj.hitFxScale)) hitFxScale = infoObj.hitFxScale;
-                    if ("hitFxRotate" in infoObj && isBoolean(infoObj.hitFxRotate)) hitFxRotate = infoObj.hitFxRotate;
-                    if ("hitFxTinted" in infoObj && isBoolean(infoObj.hitFxTinted)) hitFxTinted = infoObj.hitFxTinted;
-                    if ("hideParticles" in infoObj && isBoolean(infoObj.hideParticles)) hideParticles = infoObj.hideParticles;
-                    if ("holdKeepHead" in infoObj && isBoolean(infoObj.holdKeepHead)) holdKeepHead = infoObj.holdKeepHead;
-                    if ("holdRepeat" in infoObj && isBoolean(infoObj.holdRepeat)) holdRepeat = infoObj.holdRepeat;
-                    if ("holdCompact" in infoObj && isBoolean(infoObj.holdCompact)) holdCompact = infoObj.holdCompact;
-                    if ("colorPerfect" in infoObj && isNumber(infoObj.colorPerfect)) colorPerfect = parseRGBAfromNumber(infoObj.colorPerfect);
-                    if ("colorGood" in infoObj && isNumber(infoObj.colorGood)) colorGood = parseRGBAfromNumber(infoObj.colorGood);
-                    const progress = {
-                        tapSound: 0,
-                        dragSound: 0,
-                        flickSound: 0,
-                        tap: 0,
-                        drag: 0,
-                        flick: 0,
-                        hold: 0,
-                        tapHL: 0,
-                        dragHL: 0,
-                        flickHL: 0,
-                        holdHL: 0,
-                        hitFx: 0
-                    };
-                    const _showProgress = () => {
-                        if (progressHandler) {
-                            progressHandler({
-                                description: "读取资源包中的文件",
-                                progress: mean(Object.values(progress))
-                            });
-                        }
-                    };
-
-                    const tapSoundPromise = tapSoundFile.async("arraybuffer", meta => {
-                        progress.tapSound = meta.percent;
-                        _showProgress();
-                    }).then(MediaUtils.createAudioBuffer.bind(audioContext));
-                    const dragSoundPromise = dragSoundFile.async("arraybuffer", meta => {
-                        progress.dragSound = meta.percent;
-                        _showProgress();
-                    }).then(MediaUtils.createAudioBuffer.bind(audioContext));
-                    const flickSoundPromise = flickSoundFile.async("arraybuffer", meta => {
-                        progress.flickSound = meta.percent;
-                        _showProgress();
-                    }).then(MediaUtils.createAudioBuffer.bind(audioContext));
-                    const hitFxImagePromise = hitFxPictureFile.async("blob", meta => {
-                        progress.hitFx = meta.percent;
-                        _showProgress();
-                    }).then(MediaUtils.createImage);
-                    const
-                        tapPromise = tapPictireFile.async("blob", meta => {
-                            progress.tap = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        dragPromise = dragPictireFile.async("blob", meta => {
-                            progress.drag = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        flickPromise = flickPictireFile.async("blob", meta => {
-                            progress.flick = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        holdPromise = holdPictireFile.async("blob", meta => {
-                            progress.hold = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        tapHLPromise = tapHLPictireFile.async("blob", meta => {
-                            progress.tapHL = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        dragHLPromise = dragHLPictireFile.async("blob", meta => {
-                            progress.dragHL = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        flickHLPromise = flickHLPictireFile.async("blob", meta => {
-                            progress.flickHL = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage),
-                        holdHLPromise = holdHLPictireFile.async("blob", meta => {
-                            progress.holdHL = meta.percent;
-                            _showProgress();
-                        }).then(MediaUtils.createImage);
-                    const [tapSound, dragSound, flickSound, hitFxImage,
-                        tap, drag, flick, hold,
-                        tapHL, dragHL, flickHL, holdHL] =
-                        await Promise.all([
-                            tapSoundPromise, dragSoundPromise, flickSoundPromise, hitFxImagePromise,
-                            tapPromise, dragPromise, flickPromise, holdPromise,
-                            tapHLPromise, dragHLPromise, flickHLPromise, holdHLPromise
-                        ]);
-                    const holdHead = new EditableImage(hold)
-                        .cutTop(hold.height - holdAtlas[1])
-                        .canvas;
-                    const holdEnd = new EditableImage(hold)
-                        .cutBottom(hold.height - holdAtlas[0])
-                        .canvas;
-                    const holdBody = new EditableImage(hold)
-                        .cutTop(holdAtlas[0])
-                        .cutBottom(holdAtlas[1])
-                        .canvas;
-                    const holdHLHead = new EditableImage(holdHL)
-                        .cutTop(holdHL.height - holdAtlasMH[1])
-                        .canvas;
-                    const holdHLEnd = new EditableImage(holdHL)
-                        .cutBottom(holdHL.height - holdAtlasMH[0])
-                        .canvas;
-                    const holdHLBody = new EditableImage(holdHL)
-                        .cutTop(holdAtlasMH[0])
-                        .cutBottom(holdAtlasMH[1])
-                        .canvas;
-                    const hitFxWidth = hitFxImage.width / hitFx[0];
-                    const hitFxHeight = hitFxImage.height / hitFx[1];
-                    const perfectHitFxFrames: Image[] = [];
-                    const goodHitFxFrames: Image[] = [];
-                    for (let i = 0; i < hitFx[1]; i++) {
-                        for (let j = 0; j < hitFx[0]; j++) {
-                            const perfectHitFxFrame = new EditableImage(hitFxImage, j * hitFxWidth, i * hitFxHeight, hitFxWidth, hitFxHeight);
-                            perfectHitFxFrame.stretch(HITFX_SIZE * hitFxScale, HITFX_SIZE * hitFxScale);
-                            const goodHitFxFrame = perfectHitFxFrame.clone();
-                            const coloredFramePerfect = hitFxTinted ? perfectHitFxFrame.color(colorPerfect) : perfectHitFxFrame;
-                            const coloredFrameGood = hitFxTinted ? goodHitFxFrame.color(colorGood) : goodHitFxFrame;
-                            perfectHitFxFrames.push(coloredFramePerfect.canvas);
-                            goodHitFxFrames.push(coloredFrameGood.canvas);
-                        }
-                    }
-                    return new ResourcePackage({
-                        tap, drag, flick, holdHead, holdEnd, holdBody, hold,
-                        tapHL, dragHL, flickHL, holdHLHead, holdHLEnd, holdHLBody, holdHL,
-                        tapSound, dragSound, flickSound,
-                        perfectHitFxFrames, goodHitFxFrames,
-                        config: {
-                            hitFxDuration, hitFxRotate, hideParticles,
-                            holdKeepHead, holdRepeat, holdCompact,
-                            colorPerfect, colorGood
-                        }
-                    });
-                })
-            );
-        });
-    }
-}
-interface ResPakLoadProgress {
-
-    /** 加载描述 */
-    description: string;
-
-    /** 加载进度 */
-    progress: number;
 }

--- a/src/models/timeSegment.ts
+++ b/src/models/timeSegment.ts
@@ -1,4 +1,4 @@
-import { Beats } from "./beats";
+import { addBeats, Beats, beatsToSeconds, BPM, getBeatsValue, isGreaterThanBeats, isGreaterThanOrEqualBeats, isLessThanBeats, isLessThanOrEqualBeats, makeSureBeatsValid } from "./beats";
 
 /** 时间段，只要有开始和结束时间就可以 */
 export interface ITimeSegment {
@@ -6,4 +6,52 @@ export interface ITimeSegment {
     endTime: Beats;
     cachedStartSeconds: number;
     cachedEndSeconds: number;
+}
+export abstract class TimeSegment implements ITimeSegment {
+    _startTime: Beats = [0, 0, 1];
+    _endTime: Beats = [0, 0, 1];
+
+    get startTime() {
+        return this._startTime;
+    }
+    get endTime() {
+        return this._endTime;
+    }
+    set startTime(beats: Beats) {
+        this._startTime = makeSureBeatsValid(beats);
+        this.calculateSeconds();
+    }
+    set endTime(beats: Beats) {
+        this._endTime = makeSureBeatsValid(beats);
+        this.calculateSeconds();
+    }
+    get durationBeats() {
+        return getBeatsValue(this.endTime) - getBeatsValue(this.startTime);
+    }
+    abstract cachedStartSeconds: number;
+    abstract cachedEndSeconds: number;
+
+    abstract readonly BPMList: BPM[];
+    calculateSeconds() {
+        this.cachedStartSeconds = beatsToSeconds(this.BPMList, this.startTime);
+        this.cachedEndSeconds = beatsToSeconds(this.BPMList, this.endTime);
+    }
+
+    /** 确保 endTime 大于 startTime */
+    makeSureTimeValid() {
+        if (getBeatsValue(this.startTime) > getBeatsValue(this.endTime)) {
+            const a = this.startTime, b = this.endTime;
+            this.startTime = b;
+            this.endTime = a;
+        }
+        else if (getBeatsValue(this.startTime) === getBeatsValue(this.endTime)) {
+            this.endTime = addBeats(this.endTime, [0, 0, 1]);
+        }
+    }
+
+    isOverlapped(element: ITimeSegment, overlapWhenEqual = false) {
+        return overlapWhenEqual ?
+            isLessThanOrEqualBeats(element.startTime, this.endTime) && isGreaterThanOrEqualBeats(element.endTime, this.startTime) :
+            isLessThanBeats(element.startTime, this.endTime) && isGreaterThanBeats(element.endTime, this.startTime);
+    }
 }

--- a/src/panels/ColorEventEditPanel.vue
+++ b/src/panels/ColorEventEditPanel.vue
@@ -134,13 +134,13 @@
 </template>
 <script setup lang="ts">
 import MyButton from "@/myElements/MyButton.vue";
-import { IEvent, ColorEvent, Bezier } from "../models/event";
+import { IEvent, Bezier, IEventExtendedOptions } from "../models/event";
 import MyInput from "../myElements/MyInput.vue";
 import MySwitch from "../myElements/MySwitch.vue";
 import MySelectEasing from "@/myElements/MySelectEasing.vue";
 import { addBeats, beatsCompare, formatBeats, isEqualBeats, isLessThanOrEqualBeats, parseBeats, makeSureBeatsValid } from "@/models/beats";
 import { onBeforeUnmount, onMounted, reactive, useTemplateRef } from "vue";
-import { Ref, watch } from "vue";
+import { watch } from "vue";
 import globalEventEmitter from "@/eventEmitter";
 import store from "@/store";
 import { formatRGBcolor, isEqualRGBcolors, parseRGBcolor, RGBcolor } from "@/tools/color";
@@ -149,9 +149,9 @@ import MyGridContainer from "@/myElements/MyGridContainer.vue";
 import MathUtils from "@/tools/mathUtils";
 import MyEasing from "@/myElements/MyEasing.vue";
 import MyInputBezier from "@/myElements/MyInputBezier.vue";
-const model = defineModel<ColorEvent>({
+const model = defineModel<IEvent<RGBcolor> & IEventExtendedOptions>({
     required: true,
-}) as Ref<ColorEvent>;
+});
 const props = defineProps<{
     titleTeleport: string;
 }>();
@@ -195,7 +195,7 @@ watch(model, () => {
     switchDisabled.value?.updateShowedValue();
     inputBezier.value?.updateShowedValue();
 });
-const inputEvent: Required<IEvent<RGBcolor>> & EventExtends = reactive({
+const inputEvent: IEvent<RGBcolor> & EventExtends = reactive({
     startTime: model.value.startTime,
     endTime: model.value.endTime,
     start: model.value.start,
@@ -386,7 +386,7 @@ function swap() {
 function stick() {
     const judgeLine = store.getJudgeLineById(model.value.judgeLineNumber);
     const eventLayer = judgeLine.getEventLayerById(model.value.eventLayerId);
-    const events = eventLayer.getEventsByType(model.value.type) as ColorEvent[];
+    const events = eventLayer.getEventsByType(model.value.type) as IEvent<RGBcolor>[];
     events.sort((event1, event2) => beatsCompare(event1.endTime, event2.endTime));
 
     // 找到结束时间小于model的开始时间的最大的事件

--- a/src/panels/ErrorPanel.vue
+++ b/src/panels/ErrorPanel.vue
@@ -55,7 +55,7 @@
                             :key="object.id"
                             class="error-detail"
                         >
-                            {{ object instanceof Note ? `${object.typeString} 音符` : "事件" }} {{ object.id }}
+                            {{ isNoteLike(object) ? `${NoteType[object.type]} 音符` : "事件" }} {{ object.id }}
                             <MyButton
                                 type="success"
                                 @click.stop="goto(object)"
@@ -75,8 +75,9 @@
 <script setup lang="ts">
 import Constants from "@/constants";
 import globalEventEmitter from "@/eventEmitter";
-import { ColorEvent, NumberEvent, TextEvent } from "@/models/event";
-import { Note } from "@/models/note";
+import { SelectableElement } from "@/models/element";
+import { isEventLike } from "@/models/event";
+import { isNoteLike, NoteType } from "@/models/note";
 import MyButton from "@/myElements/MyButton.vue";
 import MySelect from "@/myElements/MySelect.vue";
 import store from "@/store";
@@ -109,9 +110,9 @@ const errorTypes = [
     }
 ];
 const errorNumberShowedDetails = ref(-1);
-function goto(object: Note | NumberEvent | ColorEvent | TextEvent) {
+function goto(object: SelectableElement) {
     stateManager.state.currentJudgeLineNumber = object.judgeLineNumber;
-    if (!(object instanceof Note)) {
+    if (isEventLike(object)) {
         stateManager.state.currentEventLayerId = object.eventLayerId;
     }
 
@@ -120,8 +121,7 @@ function goto(object: Note | NumberEvent | ColorEvent | TextEvent) {
         Constants.EDITOR_VIEW_NOTES_VIEWBOX.bottom)) {
         store.gotoBeats(object.startTime);
     }
-    selectionManager.unselectAll();
-    selectionManager.addToSelection(object);
+    selectionManager.select([object]);
 }
 
 function updateErrors() {

--- a/src/panels/MutipleEditPanel.vue
+++ b/src/panels/MutipleEditPanel.vue
@@ -272,7 +272,7 @@
     </div>
 </template>
 <script setup lang="ts">
-import { Note, NoteType } from "@/models/note";
+import { isNoteLike, Note, NoteType } from "@/models/note";
 import MyInputNumber from "@/myElements/MyInputNumber.vue";
 import MyButton from "@/myElements/MyButton.vue";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
@@ -280,7 +280,6 @@ import MyDialog from "@/myElements/MyDialog.vue";
 import globalEventEmitter from "@/eventEmitter";
 import store from "@/store";
 import MyInputBeats from "@/myElements/MyInputBeats.vue";
-import { ColorEvent, NumberEvent, TextEvent } from "@/models/event";
 import MySwitch from "@/myElements/MySwitch.vue";
 import { EasingType } from "@/models/easing";
 import MySelect from "@/myElements/MySelect.vue";
@@ -293,6 +292,7 @@ import MyInput from "@/myElements/MyInput.vue";
 import MyQuestionMark from "@/myElements/MyQuestionMark.vue";
 import { ElCheckboxButton, ElCheckboxGroup } from "element-plus";
 import MyGridContainer from "@/myElements/MyGridContainer.vue";
+import { isColorEventLike, isEventLike, isNumberEventLike, isTextEventLike } from "@/models/event";
 const props = defineProps<{
     titleTeleport: string
 }>();
@@ -403,13 +403,13 @@ const paramType = computed(() => {
             return "easing";
         }
         else {
-            if (selectionManager.selectedElements.every(element => element instanceof NumberEvent)) {
+            if (selectionManager.selectedElements.every(isNumberEventLike)) {
                 return "number";
             }
-            else if (selectionManager.selectedElements.every(element => element instanceof ColorEvent)) {
+            else if (selectionManager.selectedElements.every(isColorEventLike)) {
                 return "color";
             }
-            else if (selectionManager.selectedElements.every(element => element instanceof TextEvent)) {
+            else if (selectionManager.selectedElements.every(isTextEventLike)) {
                 return "text";
             }
             else {
@@ -588,10 +588,10 @@ function selectionUpdateHandler() {
         return;
     }
 
-    if (selectedElements.every(element => element instanceof Note)) {
+    if (selectedElements.every(element => isNoteLike(element))) {
         stateManager.cache.mutipleEdit.type = "note";
     }
-    else if (selectedElements.every(element => !(element instanceof Note))) {
+    else if (selectedElements.every(element => isEventLike(element))) {
         stateManager.cache.mutipleEdit.type = "event";
         stateManager.cache.mutipleEdit.eventTypes.length = 0;
         for (const event of selectedElements) {

--- a/src/panels/NoteEditPanel.vue
+++ b/src/panels/NoteEditPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="note-panel left-inner">
         <Teleport :to="props.titleTeleport">
-            {{ model.typeString }}音符编辑
+            {{ NoteType[model.type] }}音符编辑
         </Teleport>
         音符ID： {{ model.id }}
         <MySelectNoteType
@@ -151,7 +151,7 @@
 <script setup lang='ts'>
 import { formatBeats, makeSureBeatsValid, parseBeats } from "@/models/beats";
 import { onBeforeUnmount, onMounted, reactive, useTemplateRef, watch } from "vue";
-import { INote, Note, NoteAbove, NoteFake } from "../models/note";
+import { INote, INoteExtendedOptions, NoteAbove, NoteFake, NoteType } from "../models/note";
 import MyInput from "@/myElements/MyInput.vue";
 import MyInputNumber from "../myElements/MyInputNumber.vue";
 import MySwitch from "../myElements/MySwitch.vue";
@@ -163,7 +163,7 @@ import MyQuestionMark from "@/myElements/MyQuestionMark.vue";
 const props = defineProps<{
     titleTeleport: string
 }>();
-const model = defineModel<Note>({
+const model = defineModel<INote & INoteExtendedOptions>({
     required: true
 });
 const inputStartEndTime = useTemplateRef("inputStartEndTime");

--- a/src/panels/NumberEventEditPanel.vue
+++ b/src/panels/NumberEventEditPanel.vue
@@ -185,13 +185,13 @@
 </template>
 <script setup lang="ts">
 import MyButton from "@/myElements/MyButton.vue";
-import { Bezier, IEvent, NumberEvent } from "../models/event";
+import { Bezier, IEvent, IEventExtendedOptions } from "../models/event";
 import MyInput from "../myElements/MyInput.vue";
 import MySwitch from "../myElements/MySwitch.vue";
 import MySelectEasing from "@/myElements/MySelectEasing.vue";
 import { addBeats, beatsCompare, formatBeats, isEqualBeats, isLessThanOrEqualBeats, parseBeats, makeSureBeatsValid } from "@/models/beats";
 import { onBeforeUnmount, onMounted, reactive, useTemplateRef } from "vue";
-import { Ref, watch } from "vue";
+import { watch } from "vue";
 import globalEventEmitter from "@/eventEmitter";
 import store from "@/store";
 import MyQuestionMark from "@/myElements/MyQuestionMark.vue";
@@ -200,9 +200,9 @@ import { ElTooltip } from "element-plus";
 import MyInputBezier from "@/myElements/MyInputBezier.vue";
 import MyEasing from "@/myElements/MyEasing.vue";
 import MathUtils from "@/tools/mathUtils";
-const model = defineModel<NumberEvent>({
+const model = defineModel<IEvent<number> & IEventExtendedOptions>({
     required: true,
-}) as Ref<NumberEvent>;
+});
 const props = defineProps<{
     titleTeleport: string;
 }>();
@@ -247,7 +247,7 @@ watch(model, () => {
     selectEasing.value?.updateShowedValue();
     switchDisabled.value?.updateShowedValue();
 });
-const inputEvent: Required<IEvent<number>> & EventExtends = reactive({
+const inputEvent: IEvent<number> & EventExtends = reactive({
     startTime: model.value.startTime,
     endTime: model.value.endTime,
     start: model.value.start,
@@ -422,7 +422,7 @@ function swap() {
 function stick() {
     const judgeLine = store.getJudgeLineById(model.value.judgeLineNumber);
     const eventLayer = judgeLine.getEventLayerById(model.value.eventLayerId);
-    const events = eventLayer.getEventsByType(model.value.type) as NumberEvent[];
+    const events = eventLayer.getEventsByType(model.value.type) as IEvent<number>[];
     events.sort((event1, event2) => beatsCompare(event1.endTime, event2.endTime));
 
     // 找到结束时间小于model的开始时间的最大的事件

--- a/src/panels/TextEventEditPanel.vue
+++ b/src/panels/TextEventEditPanel.vue
@@ -136,22 +136,22 @@
 </template>
 <script setup lang="ts">
 import MyButton from "@/myElements/MyButton.vue";
-import { Bezier, IEvent, TextEvent } from "../models/event";
+import { Bezier, IEvent, IEventExtendedOptions } from "../models/event";
 import MyInput from "../myElements/MyInput.vue";
 import MySwitch from "../myElements/MySwitch.vue";
 import MySelectEasing from "@/myElements/MySelectEasing.vue";
 import { addBeats, beatsCompare, formatBeats, isEqualBeats, isLessThanOrEqualBeats, parseBeats, makeSureBeatsValid } from "@/models/beats";
 import { onBeforeUnmount, onMounted, reactive, useTemplateRef } from "vue";
-import { Ref, watch } from "vue";
+import { watch } from "vue";
 import globalEventEmitter from "@/eventEmitter";
 import store from "@/store";
 import MyQuestionMark from "@/myElements/MyQuestionMark.vue";
 import MyGridContainer from "@/myElements/MyGridContainer.vue";
 import MyEasing from "@/myElements/MyEasing.vue";
 import MyInputBezier from "@/myElements/MyInputBezier.vue";
-const model = defineModel<TextEvent>({
+const model = defineModel<IEvent<string> & IEventExtendedOptions>({
     required: true,
-}) as Ref<TextEvent>;
+});
 const props = defineProps<{
     titleTeleport: string;
 }>();
@@ -196,7 +196,7 @@ watch(model, () => {
     switchDisabled.value?.updateShowedValue();
     inputBezier.value?.updateShowedValue();
 });
-const inputEvent: Required<IEvent<string>> & EventExtends = reactive({
+const inputEvent: IEvent<string> & EventExtends = reactive({
     startTime: model.value.startTime,
     endTime: model.value.endTime,
     start: model.value.start,
@@ -345,7 +345,7 @@ function swap() {
 function stick() {
     const judgeLine = store.getJudgeLineById(model.value.judgeLineNumber);
     const eventLayer = judgeLine.getEventLayerById(model.value.eventLayerId);
-    const events = eventLayer.getEventsByType(model.value.type) as TextEvent[];
+    const events = eventLayer.getEventsByType(model.value.type) as IEvent<string>[];
     events.sort((event1, event2) => beatsCompare(event1.endTime, event2.endTime));
 
     // 找到结束时间小于model的开始时间的最大的事件

--- a/src/tools/assertion.ts
+++ b/src/tools/assertion.ts
@@ -1,7 +1,9 @@
 import { isString } from "lodash";
 import { Typeof } from "./typeTools";
 
-/** 用于给输入的数据进行检查 */
+/**
+ * 用于给输入的数据进行检查，类似于 Python 中的 assert 语句
+ */
 export default class Assertion {
     value: unknown;
     constructor(value: unknown) {

--- a/src/tools/mathUtils.ts
+++ b/src/tools/mathUtils.ts
@@ -6,6 +6,14 @@ export const KB_TO_BYTE = 1024;
 export const HOUR_TO_MIN = 60;
 export const MIN_TO_SEC = 60;
 export const SEC_TO_MS = 1000;
+
+/**
+ * 所有与坐标计算相关的方法，角度为 0 时向右，角度为 90 时向下，
+ * 因为在 RPE 中，0 度代表判定线面向上方，此时向右为判定线的x轴正方向；
+ * 90 度代表判定线面向右方，此时向下为判定线的x轴正方向
+ *
+ * @class 数学工具类
+ */
 export default class MathUtils {
     /**
      * 求从 (x1, y1) 点往 dir 方向移动 x2，左转 90 度，再移动 y2 得到的坐标
@@ -33,8 +41,11 @@ export default class MathUtils {
     }
 
     /**
-     * 把以 (x, y) 为原点的极坐标转换为直角坐标
-     * theta 为 0 表示向右（X轴正方向），为 90 表示向下（Y轴负方向）
+     * 以直角坐标系的 (x, y) 为原点建立极坐标系，然后将极坐标转换为直角坐标
+     * @param x 极坐标原点在直角坐标系中的x坐标
+     * @param y 极坐标原点在直角坐标系中的y坐标
+     * @param theta 点在极坐标原点的方向，为 0 表示向右（X轴正方向），为 90 表示向下（Y轴负方向）
+     * @param r 点离极坐标原点的距离
      */
     static pole(x: number, y: number, theta: number, r: number) {
         return this.moveAndRotate(x, y, theta, r, 0);

--- a/src/tools/typeTools.ts
+++ b/src/tools/typeTools.ts
@@ -43,6 +43,7 @@ export type DeepReadonly<T> = {
     readonly [P in keyof T]: DeepReadonly<T[P]>;
 };
 
+/** 深度搜索把每个属性都变为非只读 */
 export type DeepNotReadonly<T> = {
     -readonly [P in keyof T]: DeepNotReadonly<T[P]>;
 };
@@ -53,6 +54,7 @@ export type Filter<T, U> = T extends U ? T : never;
 /** 判断两个类型是否相等 */
 export type IsEqual<T, U> = [T] extends [U] ? [U] extends [T] ? true : false : false;
 
+/** 创建一个键值对象，其中所有属性都是可选的 */
 export type PartialRecord<K extends string | number | symbol, V> = { [P in K]?: V };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -70,6 +72,8 @@ export type UnionToIntersection<U> =
     : never;
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+export type NotEmpty = NonNullable<unknown>;
 
 /* eslint-disable no-magic-numbers, no-loss-of-precision */
 export type Infinity = 1e114514;


### PR DESCRIPTION
### 修改目的

将 models 文件夹下的代码进行了重构，添加了接口以遵循依赖倒置原则
使 managers 下的文件不直接依赖具体的 Note、NumberEvent、ColorEvent、TextEvent 等具体实现，而是依赖抽象接口。
`CONTRIBUTING.md` 文档也已经添加了关于此内容的开发规则。

### 测试情况

已通过 build.cmd 构建测试，重构代码后功能未受影响。